### PR TITLE
Guard $1 if zero arguments

### DIFF
--- a/shell/scl_source
+++ b/shell/scl_source
@@ -9,7 +9,7 @@ Options:
 
 if [ $# -eq 0 -o X"$1" = X"-h" -o X"$1" = X"--help" ]; then
     echo "$_scl_source_help"
-    return 0
+    return 1
 fi
 
 

--- a/shell/scl_source
+++ b/shell/scl_source
@@ -7,7 +7,7 @@ Don't use this script outside of SCL scriptlets!
 Options:
     -h, --help    display this help and exit"
 
-if [ $# -eq 0 -o $1 = "-h" -o $1 = "--help" ]; then
+if [ $# -eq 0 -o X"$1" = X"-h" -o X"$1" = X"--help" ]; then
     echo "$_scl_source_help"
     return 0
 fi


### PR DESCRIPTION
Original crashed on `./scl_source` and didn't display help as expected.

Before: `./scl_source: line 10: [: too many arguments`

After: Properly displays help
