### PR TITLE
macros: don't always expect brp-java-repack-jars

### DIFF
--- a/rpm/macros.scl
+++ b/rpm/macros.scl
@@ -91,7 +91,6 @@ package or when debugging this package.
     /usr/lib/rpm/brp-strip-static-archive %{__strip}
     /usr/lib/rpm/brp-scl-python-bytecompile %{__python} %{?_python_bytecompile_errors_terminate_build} %{_scl_root}
     /usr/lib/rpm/brp-python-hardlink
-    %{!?__jar_repack:/usr/lib/rpm/redhat/brp-java-repack-jars}
 %{nil}}
 BuildRequires: scl-utils-build
 %if "%{?scl}%{!?scl:0}" == "%{pkg_name}"


### PR DESCRIPTION
This script has been dropped from redhat-rpm-config in F26+
(package commit 3234495f75b7a89879ce3e1c37f6bd6c779615d5)