### PR TITLE
file attribute processing bugs

### DIFF
--- a/rpm/scl.attr
+++ b/rpm/scl.attr
@@ -1,3 +1,3 @@
 %__scl_provides	%{_rpmconfigdir}/scldeps.sh --provides %{scl}
 %__scl_requires %{_rpmconfigdir}/scldeps.sh --requires %{scl_runtime}
-%__scl_path	%{?scl:^%{_scl_prefix}/.*$ || %{_root_sysconfdir}/rpm/macros.%{scl}-config$}
+%__scl_path	%{?scl:^%{_scl_prefix}/.*|%{_root_sysconfdir}/rpm/macros.%{scl}-config$}

--- a/rpm/sclbuild.attr
+++ b/rpm/sclbuild.attr
@@ -1,4 +1,4 @@
 %__sclbuild_provides %{_rpmconfigdir}/scldeps.sh --provides %{scl}
 %__sclbuild_requires %{_rpmconfigdir}/scldeps.sh --requires scl-utils-build %{scl_runtime}
-%__sclbuild_path     %{?scl:%{_root_sysconfdir}/rpm/macros.%{scl}-config$}
+%__sclbuild_path     %{?scl:^%{_root_sysconfdir}/rpm/macros.%{scl}-config$}
 

--- a/rpm/scldeps.sh
+++ b/rpm/scldeps.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+# Read all the input!
+cat > /dev/null
+
 [ $# -ge 2 ] || {
-    cat > /dev/null
     exit 0
 }
 
@@ -13,7 +15,7 @@ case $option in
     echo -n "scl-package($1)"
     ;;
 -R|--requires)
-    for o in $@; do
+    for o in "$@"; do
         echo "$o"
     done
     ;;


### PR DESCRIPTION
Based on [1], the script should read all the lines from stdin and
process them.  We don't need this functionality, though not
processing whole the stdin means that SIGPIPE is (might be) thrown
by kernel.

On Fedora 27, SIGPIPE caused rpmbuild's exit status 141, and no
useful error output was thrown out:

  Processing files: sclo-postgresql96-3.0-2.fc27.x86_64
  Processing files: sclo-postgresql96-runtime-3.0-2.fc27.x86_64
  Executing(%doc): /bin/sh -e /var/tmp/rpm-tmp.2X52o3
  + umask 022
  + cd /builddir/build/BUILD
  + cd sclo-postgresql96-3.0
  + DOCDIR=/builddir/build/BUILDROOT/sclo-postgresql96-3.0-2....
  + export DOCDIR
  + /usr/bin/mkdir -p /builddir/build/BUILDROOT/sclo-postgres...
  + cp -pr README /builddir/build/BUILDROOT/sclo-postgresql96...
  + cp -pr LICENSE /builddir/build/BUILDROOT/sclo-postgresql9...
  + exit 0
  ERROR: Exception(intermediate-srpm/sclo-postgresql96-3.0-2....
  INFO: Results and/or logs in: /var/lib/copr-builder/results
  INFO: Cleaning up build root ('cleanup_on_failure=True')
  Start: clean chroot
  INFO: unmounting tmpfs.
  Finish: clean chroot
  ERROR: Command failed. See logs for output.

Also fix shell bug in "$@" processing.

[1] http://rpm.org/user_doc/dependency_generators.html