### PR TITLE
Exit script rather than return outside of function

### DIFF
--- a/shell/scl_source
+++ b/shell/scl_source
@@ -9,7 +9,7 @@ Options:
 
 if [ $# -eq 0 -o $1 = "-h" -o $1 = "--help" ]; then
     echo "$_scl_source_help"
-    return 0
+    exit 0
 fi
 
 
@@ -36,7 +36,7 @@ for arg in "$@"; do
     _scl_prefix=`cat $_scl_prefix_file 2> /dev/null`
     if [ $? -ne 0 ]; then
         echo "Can't read $_scl_prefix_file, $arg is probably not installed."
-        return 1
+        exit 1
     fi
   
     # First check if the collection is already in the list


### PR DESCRIPTION
As scl_source calls `return` outside of function, it always output
error message when some option was executed. For example, `scl_source
-h` produces an error `/usr/bin/scl_
source: line 12: return: can only `return' from a function or sourced
script`.

This patch changes `return` to `exit` and fix the error message.

- Current help output (Please notice the bottom line.)

```
[root@knakayam-rhel7-work ~]# scl_source -h
Usage: source scl_source <action> [<collection> ...]

Don't use this script outside of SCL scriptlets!

Options:
    -h, --help    display this help and exit
/usr/bin/scl_source: line 12: return: can only `return' from a function or sourced script
```