### PR TITLE
Fix wrong bash test in scl_source command

### DIFF
--- a/shell/scl_source
+++ b/shell/scl_source
@@ -7,7 +7,7 @@ Don't use this script outside of SCL scriptlets!
 Options:
     -h, --help    display this help and exit"
 
-if [ $# -eq 0 -o $1 = "-h" -o $1 = "--help" ]; then
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     echo "$_scl_source_help"
     return 0
 fi


### PR DESCRIPTION
Running scl_source command without any arg fails to output help
message due to the wrong bash implementation as below:

~~~
$ scl_source 
/usr/bin/scl_source: line 10: [: too many arguments
~~~

or

~~~
$ source scl_source 
bash: [: too many arguments
~~~

This patch fix the bash expression and output help message correctly.
