### PR TITLE
Fix crashes in "scl list-enabled":

### DIFF
--- a/src/lib_common.c
+++ b/src/lib_common.c
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <wordexp.h>
+#include <assert.h>
 
 #include "errors.h"
 #include "scllib.h"
@@ -268,6 +269,10 @@ char **merge_string_arrays(char *const *array1, char *const *array2)
         }
     }
     merged_array[++prev] = NULL;
+
+    for (int i = 0; i < prev; i++) {
+        merged_array[i] = xstrdup(merged_array[i]);
+    }
 
     return merged_array;
 }

--- a/src/scllib.c
+++ b/src/scllib.c
@@ -107,8 +107,8 @@ scl_rc get_enabled_collections(char ***_enabled_collections)
                 sizeof(SCL_MODULES_PATH - 1))){
 
                 enabled_collections[i] += sizeof(SCL_MODULES_PATH);
-                enabled_collections[i] = xstrdup(enabled_collections[i]);
             }
+            enabled_collections[i] = xstrdup(enabled_collections[i]);
         }
 
     }


### PR DESCRIPTION
* src/lib_common.c (merge_string_arrays):
  Ensure elements of returned array are strdup()ed.

* src/scllib.c (get_enabled_collections):
  Ensure all elements of returned array are strdup()ed.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1728450