### PR TITLE
use $SHELL before processlist

### DIFF
--- a/shell/scl-init.sh
+++ b/shell/scl-init.sh
@@ -9,8 +9,12 @@ else
 fi
 }
 
-shell=`/bin/basename \`/bin/ps -p $$ -ocomm=\``
-[ "$shell" = "bash" ] && export -f scl # export -f works only in bash
+if [ -v SHELL ]; then
+   [[ $SHELL =~ \/bash$ ]] && export -f scl # export -f works only in bash
+else
+   shell=`/bin/basename \`/bin/ps -p $$ -ocomm=\``
+   [ "$shell" = "bash" ] && export -f scl # export -f works only in bash
+fi
 
 MODULESHOME=/usr/share/Modules
 export MODULESHOME


### PR DESCRIPTION
it would be nice not use the processlist as first check because it
dosn't work on systems that have no access to /proc