### PR TITLE
Replace %{__python} with %{__python3}.

### DIFF
--- a/rpm/macros.scl
+++ b/rpm/macros.scl
@@ -90,7 +90,7 @@ package or when debugging this package.
     /usr/lib/rpm/brp-strip-comment-note %{__strip} %{__objdump}
     }
     /usr/lib/rpm/brp-strip-static-archive %{__strip}
-    /usr/lib/rpm/brp-scl-python-bytecompile %{__python} %{?_python_bytecompile_errors_terminate_build} %{_scl_root}
+    /usr/lib/rpm/brp-scl-python-bytecompile %{__python3} %{?_python_bytecompile_errors_terminate_build} %{_scl_root}
     /usr/lib/rpm/brp-python-hardlink
 %{nil}}
 BuildRequires: scl-utils-build


### PR DESCRIPTION
To fix the following error.

```
$ rhpkg srpm
error: attempt to use unversioned python, define %__python to /usr/bin/python2 or /usr/bin/python3 explicitly
```

I faced the following error on Fedora 33 with SCL meta package rh-ruby27.spec. This PR fixes the error.

```
$ rpm -q scl-utils-build
scl-utils-build-2.0.2-16.fc33.x86_64

$ rhpkg srpm 
error: attempt to use unversioned python, define %__python to /usr/bin/python2 or /usr/bin/python3 explicitly
error: /home/jaruga/git/pkg/rh/rh-ruby27/rh-ruby27.spec: line 13: Macro %__os_install_post failed to expand
error: query of specfile /home/jaruga/git/pkg/rh/rh-ruby27/rh-ruby27.spec failed, can't parse

Could not execute srpm: Could not get n-v-r-e from /home/jaruga/git/pkg/rh/rh-ruby27/rh-ruby27.spec
```
