### PR TITLE
Let scl_source behave when "-e"/errexit is set

### DIFF
--- a/shell/scl_source
+++ b/shell/scl_source
@@ -47,8 +47,7 @@ for arg in "$@"; do
     done
 
     # Now check if the collection isn't already enabled
-    /usr/bin/scl_enabled $arg > /dev/null 2> /dev/null
-    if [ $? -ne 0 ]; then
+    if ! /usr/bin/scl_enabled $arg > /dev/null 2> /dev/null; then
         _scls+=($arg)
         _scl_prefixes+=($_scl_prefix)
     fi;


### PR DESCRIPTION
Jenkins pipelines, among other things, use `set -e` (aka bash `errexit`) to abort on "errors". So when `source scl_source` is used in a pipeline, the way the exit code from `scl_enabled` is checked via `$?` causes an unintended abort of the pipeline. (Workaround is to use `set +e; source scl_source ...; set -e`.)

This trivial change to `scl_source` simply changes how the value of `scl_enalbed` is checked to be friendly to `errexit`.