### PR TITLE
Make the python3 be the default choice

### DIFF
--- a/rpm/brp-scl-python-bytecompile
+++ b/rpm/brp-scl-python-bytecompile
@@ -10,7 +10,7 @@ fi
 [ "0$scl_path" = "0" ] && exit 0
 
 # If we don't have a python interpreter, avoid changing anything.
-default_python=${1:-/usr/bin/python}
+default_python=${1:-/usr/bin/python3}
 if [ ! -x "$default_python" ]; then
 	exit 0
 fi


### PR DESCRIPTION
This default is likely never used but since it is there, let's make it valid.

scl-utils 2.x are included only in RHEL-8, so it is likely safe to expect
python3 being available everywhere where 2.x version of scl-utils is
used.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1984598