### PR TITLE
[test] Fix CMAKE_C_FLAGS

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 ENABLE_TESTING()
 INCLUDE_DIRECTORIES(. ../src ${PROJECT_BINARY_DIR}/src )
-SET( CMAKE_C_FLAGS "-Wall -pedantic --std=gnu99 -D_GNU_SOURCE -g -Wl,--wrap=get_command_output -Wl,--wrap=system -Wl,--wrap=putenv -Wl,--wrap=getenv ${CMAKE_C_FLAGS}" )
+SET( CMAKE_C_FLAGS "-Wall -pedantic --std=gnu99 -D_GNU_SOURCE -g -fPIE -Wl,--wrap=get_command_output -Wl,--wrap=system -Wl,--wrap=putenv -Wl,--wrap=getenv" )
 
 
 SET(tested_sources ../src/scllib.c ../src/sclmalloc.c ../src/lib_common.c ../src/debug.c ../src/fallback.c)


### PR DESCRIPTION
OK, it turns out we can't append the default CMAKE_C_FLAGS after all,
because they may contain LTO flags and those may not work with --wrap
(rhbz#1693831).

Instead, just add the -fPIE flag, which solves the original linking
issue I was having before the previous commit when building the 2.0.3
version in CentOS Stream 9:

/usr/bin/ld: CMakeFiles/test_scllib.dir/test_scllib.c.o: relocation
R_X86_64_32 against symbol `env' can not be used when making a PIE
object; recompile with -fPIE

I'm not quite sure why the test executables need to be built as PIE, but
let's go with the linker's suggestion here as it won't hurt anything and
will actually fix the issue.