### PR TITLE
Update brp-python-hardlink path

### DIFF
--- a/rpm/macros.scl
+++ b/rpm/macros.scl
@@ -91,7 +91,7 @@ package or when debugging this package.
     }
     /usr/lib/rpm/brp-strip-static-archive %{__strip}
     /usr/lib/rpm/brp-scl-python-bytecompile %{__python3} %{?_python_bytecompile_errors_terminate_build} %{_scl_root}
-    /usr/lib/rpm/brp-python-hardlink
+    [ -f /usr/lib/rpm/redhat/brp-python-hardlink ] && /usr/lib/rpm/redhat/brp-python-hardlink || /usr/lib/rpm/brp-python-hardlink
 %{nil}}
 BuildRequires: scl-utils-build
 %if "%{?scl}%{!?scl:0}" == "%{pkg_name}"


### PR DESCRIPTION
Since Fedora 35 `brp-python-hardlink` script is in `/usr/lib/rpm/redhat/`.
Otherwise RPM build fails with:

    + /usr/lib/rpm/brp-python-hardlink
    /var/tmp/rpm-tmp.VsVGRP: line 312: /usr/lib/rpm/brp-python-hardlink: No such file or directory

Fixes #42