### PR TITLE
avoid bare words are no longer supported (rpm 4.20)

### DIFF
--- a/rpm/macros.scl
+++ b/rpm/macros.scl
@@ -10,7 +10,7 @@
 %if "%{?old_debug}" == "0"
        %{expand: %{nil}}
 %else
-%if "%{?scl}%{!?scl:0}" == "%{pkg_name}"
+%if 0
         %{expand: %{nil}}
 %else
 %ifnarch noarch
@@ -94,7 +94,7 @@ package or when debugging this package.
     [ -f /usr/lib/rpm/redhat/brp-python-hardlink ] && /usr/lib/rpm/redhat/brp-python-hardlink || /usr/lib/rpm/brp-python-hardlink
 %{nil}}
 BuildRequires: scl-utils-build
-%if "%{?scl}%{!?scl:0}" == "%{pkg_name}"
+%if 0
 Requires: %{scl_runtime}
 Provides: scl-package(%{scl})
 %endif


### PR DESCRIPTION
scl build are failing in Fedora 41

```
RPM build errors:
error: bare words are no longer supported, please use "...":  php83 == php
error:                                                        ^
error: /builddir/build/BUILD/php83-php-8.3.11_RC1-build/SPECPARTS/rpm-debuginfo.specpart:5: bad %if condition:  php83 == php
error: parsing failed
    bare words are no longer supported, please use "...":  php83 == php
                                                           ^
    /builddir/build/BUILD/php83-php-8.3.11_RC1-build/SPECPARTS/rpm-debuginfo.specpart:5: bad %if condition:  php83 == php
    parsing failed

```

I don't find an easy way to fix the test, so choose to ignore it, but it is only there to avoid empty debuginfo package when building the SCL metapackage, which already have `%global debug_package %{nil}`

This is obviously only a trivial **workaround**, but it works